### PR TITLE
Add MyDNS.JP Dynamic DNS Service

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -149,6 +149,13 @@ Organization Website:
 Provide the website address of 
 the Org as a full URL i.e. https://example.com 
 -->
+https://www.mydns.jp/
+
+Hello. We provide the Dynamic DNS service for free of charge to any registered users worldwide since 2000.
+Using our service, anyone can register any hostname (subdomain) of their choice under any domain with associated IPv4 and IPv6 addresses.
+A certain user uses it for a web server. Another user uses it for VPN, various remote operations, and security.
+We offer several domain names, depending on the goals and preferences of our users.
+For example, we offer (1) mydns.jp, (2) pgw.jp, (3) wjg.jp, (4) 0am.jp, and others.
 
 Reason for PSL Inclusion
 ====
@@ -172,12 +179,26 @@ Three or more sentences here that describe the purpose for
 which your PR should be included in the PSL.  There is no 
 upper limit, but six paragraphs seems like a rational stop.
 -->
+All of the domains we are offering will be retained for a minimum of two years.
+However, for Japanese domains (.jp), due to the Japanese registrar system(JPRS), they will not expire for more than two years, even after checking with whois.
+Of course, since all of our domains are auto-renewed, this is not a problem.
+
+Our dynamic DNS service is designed to allow registration on a subdomain basis.
+This means that each website on a subdomain is independent.
+For security, cookies must be separated between independent sites.
+
+https://www.google.com/search?q=site%3Amydns.jp
+https://www.google.com/search?q=site%3Apgw.jp
+https://www.google.com/search?q=site%3Awjg.jp
 
 Number of users this request is being made to serve:
 <!--
 Identify if this is current or an estimate.
 -->
-
+site:mydns.jp	396,000 hosts.
+site:pgw.jp		10,600 hosts.
+site:wjg.jp		10,400 hosts.
+... on Feb 19, 2024.
 
 DNS Verification via dig
 =======
@@ -206,6 +227,7 @@ your entry to remain in the PSL, so that future (TBD)
 automation can remove entries where the record is not present.
 
 -->
+
 
 Results of Syntax Checker (`make test`)
 =========

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -13273,6 +13273,24 @@ freemyip.com
 // Submitted by Daniel A. Maierhofer <vorstand@funkfeuer.at>
 wien.funkfeuer.at
 
+// Future Versatile Group. ：https://www.fvg-on.net/
+// T.Kabu <kabu@fvg-on.net>
+0am.jp
+0g0.jp
+0j0.jp
+0t0.jp
+daemon.asia
+dix.asia
+keyword-on.net
+live-on.net
+mydns.bz
+mydns.jp
+mydns.tw
+mydns.vc
+pgw.jp
+server-on.net
+wjg.jp
+
 // Futureweb GmbH : https://www.futureweb.at
 // Submitted by Andreas Schnederle-Wagner <schnederle@futureweb.at>
 *.futurecms.at


### PR DESCRIPTION
Public Suffix List (PSL) Pull Request (PR) Template
====

Each PSL PR needs to have a description, rationale, indication of DNS validation and syntax checking, as well as a number of acknowledgements from the submitter.  This template must be included with each PR, and the submitting party MUST provide responses to all of the elements in order to be considered.

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

Also, read them again, as many skip that part and 
get confused about why their PR is delayed or does
not get accepted when theirs didn't follow them.

A recent PR using the current template is 
https://github.com/publicsuffix/list/pull/1591, although 
the organization and description were not as substantial 
as desired, which required maintainers time to visit the 
requestors website to further research. 
Having more robust org/desc improves the PR processing 
pace due to the extra cycles not lost to research.
For an example of what an excellent description in a PR looks like
see https://github.com/publicsuffix/list/pull/615, 
although that example uses an earlier template.
-->
### Checklist of required steps

* [x] Description of Organization
* [x] Robust Reason for PSL Inclusion
* [ ] DNS verification via dig
* [ ] Run Syntax Checker (make test)

* [ ] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration, and we shall keep the \_PSL txt record in place in the respective zone(s) in the affected section

__Submitter affirms the following:__ 
<!--
Third-party Limits are used elsewhere, such as at Cloudflare, Let's 
Encrypt, Apple, GitLab or others, and having an entry in the PSL alters 
the manner in which those third-party systems or products treat 
a given domain name or sub-domains within it.

To be clear, it is appropriate to address how those limits impact 
your domain(s) directly with that third-party, and it is inappropriate 
to submit entries to the PSL as a means to work around those limits or 
restrictions.
-->
  * [ ] We are listing *any* third-party limits that we seek to work around in our rationale such as those between IOS 14.5+ and Facebook (see [Issue #1245](https://github.com/publicsuffix/list/issues/1245) as a well-documented example)

<!--
The purpose of the question above is to expose limit workarounds.
If there are third party limits that the PR seeks to overcome, those
must be listed within the rationale section of this request, and 
provide a good level of detail the effort that was made to work directly 
with the third part(y|ies) in attempting to address this within their 
rationale response below.
In all cases, software and services should be discouraged from use of
the PSL as a rate-limiting tool, and provide clear instructions to their
own clients, partners and users on the manner in which they can directly
request rate limit increases.
We treat the following as an attestation in the public record of the 
requesting party that they are not attempting to bypass rate limits through
the PR.
-->

  * [ ] This request was _not_ submitted with the objective of working around other third-party limits

<!--
The guidelines describe which section to place the entry, what the 
order of commented org placement, order of sorting of entries. 
(hint: TLD then SLD, Ascending sort)   Although it seems pedantic, 
the sorting and formatting rules help ensure all of the automation 
that uses the PSL operates correctly.  Typically both are solved or
neither.
-->

  * [ ] The [Guidelines](https://github.com/publicsuffix/list/wiki/Guidelines) were carefully _read_ and _understood_, and this request conforms
  * [ ] The submission follows the [guidelines](https://github.com/publicsuffix/list/wiki/Format) on formatting and sorting

<!-- 
Sorting and formatting of the entries is outlined in the guidelines 
and non-conforming requests are one of the largest sources of delay,
so getting this right initially will aid successfully having it 
proceed.  Miss-located entries and trailing spaces should be avoided.
-->

---

For Private section requests that are submitting entries for domains that match their organization website's primary domain, please understand that this can have impacts that may not match the desired outcome and take a long time to rollback, if at all.

To ensure that requested changes are entirely intentional, make sure that you read the affectation and propagation expectations, that you understand them, and confirm this understanding. 

PR Rollbacks have lower priority, and the volunteers are unable to control when or if browsers or other parties using the PSL will refresh or update.

<!-- 
Seriously, carefully read the downline flow of the PSL and the 
guidelines. Your request could very likely alter the cookie and 
certificate (as well as other) behaviours on your core domain name in 
ways that could be problematic for your business.

Rollback is really not predictable, as those who use or incorporate 
the PSL do what they do, and when. It is not within the PSL volunteers' 
control to do anything about that.  

The volunteers are busy with new requests, and rollbacks are lowest 
priority, so if something gets broken by your PR, it will potentially 
stay that way for an indefinite period of time (typically long).
-->

(Link: [about propagation/expectations](https://github.com/publicsuffix/list/wiki/Guidelines#appropriate-expectations-on-derivative-propagation-use-or-inclusion))

 * [ ] *Yes, I understand*.  I could break my organization's website cookies etc. and the rollback timing, etc is acceptable.  *Proceed*.
---


<!--

As you complete each item in the checklist please mark it with an X

Example:

* [x] Description of Organization

-->

Description of Organization
====

<!--
PROVIDE AT LEAST THREE SENTENCES (the more the better) but
avoid the promotional stuff about how wonderful it is, and 
please do not copy and paste the mission statement or 
elevator pitch from your org's website.

Also tell us who you (submitter) are and represent (i.e. 
individual, non-profit volunteer, engineer at a business) 
and what you do (i.e. DynDNS, Hosting, etc), and what your 
role is as submitter with respect to the org and the 
submission.

For the org description, there is less interest in the 
promotional / marketing information about the org and more 
a focus on having concise description of the core focus of 
the submitting org, specifically with context/connection 
to this request.
-->

Organization Website: 
<!-- 
Provide the website address of 
the Org as a full URL i.e. https://example.com 
-->
https://www.mydns.jp/

Hello. We provide the Dynamic DNS service for free of charge to any registered users worldwide since 2000.
Using our service, anyone can register any hostname (subdomain) of their choice under any domain with associated IPv4 and IPv6 addresses.
A certain user uses it for a web server. Another user uses it for VPN, various remote operations, and security.
We offer several domain names, depending on the goals and preferences of our users.
For example, we offer (1) mydns.jp, (2) pgw.jp, (3) wjg.jp, (4) 0am.jp, and others.

Reason for PSL Inclusion
====

<!--
Please tell us why your domain(s) should be listed in the PSL
(i.e. Cookie Security, Let's Encrypt issuance, IOS/Facebook, 
Cloudflare etc) and clearly confirm that any private section 
names hold registration term longer than 2 years and shall 
maintain more than 1 year term in order to remain listed.

If you are attempting to work around third party limits, use 
this area to describe how and detail the manner in which you 
have first attempted to engage those third parties on the 
matter.

Please also include the numbers of any past Issue # or PR # 
specifically related to this submission or section.

Three or more sentences here that describe the purpose for 
which your PR should be included in the PSL.  There is no 
upper limit, but six paragraphs seems like a rational stop.
-->
All of the domains we are offering will be retained for a minimum of two years.
However, for Japanese domains (.jp), due to the Japanese registrar system(JPRS), they will not expire for more than two years, even after checking with whois.
Of course, since all of our domains are auto-renewed, this is not a problem.

Our dynamic DNS service is designed to allow registration on a subdomain basis.
This means that each website on a subdomain is independent.
For security, cookies must be separated between independent sites.

https://www.google.com/search?q=site%3Amydns.jp
https://www.google.com/search?q=site%3Apgw.jp
https://www.google.com/search?q=site%3Awjg.jp

Number of users this request is being made to serve:
<!--
Identify if this is current or an estimate.
-->
site:mydns.jp	396,000 hosts.
site:pgw.jp		10,600 hosts.
site:wjg.jp		10,400 hosts.
... on Feb 19, 2024.

DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.

We ask that you leave this record in place while you want 
your entry to remain in the PSL, so that future (TBD) 
automation can remove entries where the record is not present.

-->


Results of Syntax Checker (`make test`)
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test and those results
-->


